### PR TITLE
Iterations benchmark

### DIFF
--- a/apps/max_contention_bench/max_contention_bench.cpp
+++ b/apps/max_contention_bench/max_contention_bench.cpp
@@ -12,7 +12,7 @@
 #include "bakery_mutex.cpp"
 
 
-void max_contention_bench(int num_threads, int num_iterations, bool csv, bool thread_level, SoftwareMutex* lock) {
+int max_contention_bench(int num_threads, std::chrono::seconds run_time, bool csv, SoftwareMutex* lock) {
 
     // Create run args structure to hold thread arguments
     // struct run_args args;
@@ -28,25 +28,23 @@ void max_contention_bench(int num_threads, int num_iterations, bool csv, bool th
 
     // Create a flag to signal the threads to start
     std::shared_ptr<std::atomic<bool>> start_flag = std::make_shared<std::atomic<bool>>(false);
+    std::shared_ptr<std::atomic<bool>> end_flag = std::make_shared<std::atomic<bool>>(false);
     volatile int *counter = (volatile int*)malloc(sizeof(int));
 
     // Create an array of thread arguments
     std::vector<per_thread_args> thread_args(num_threads);
     for (int i = 0; i < num_threads; ++i) {
         thread_args[i].thread_id = i;
-        thread_args[i].stats.num_iterations = num_iterations;
         thread_args[i].lock = lock; // Pass the lock to each thread
+        thread_args[i].stats.run_time=run_time;
     }
 
     // Create an array of threads
     std::vector<std::thread> threads(num_threads);
     for (int i = 0; i < num_threads; ++i) {
         thread_args[i].start_flag = start_flag; // Share the start flag with each thread
-        // I put the if statement here rather than inside the thread code so that fewer conditionals have to be checked
-        // in the runtime-importants section
-        if (thread_level) {
-            // Measure how long each thread takes to finish
-            threads[i] = std::thread([&thread_args, i, counter]() {
+        thread_args[i].end_flag = end_flag;
+        threads[i] = std::thread([&thread_args, i, counter]() {
 
                 // Record the thread ID
                 thread_args[i].stats.thread_id = thread_args[i].thread_id;
@@ -56,47 +54,24 @@ void max_contention_bench(int num_threads, int num_iterations, bool csv, bool th
                     // Wait until the start flag is set
                 }
 
-                // Start the timer for this thread
-                start_timer(&thread_args[i].stats);
-
+            while(!*thread_args[i].end_flag){
                 // Perform the locking operations
-                for (int j = 0; j < thread_args[i].stats.num_iterations; ++j) {
-                    thread_args[i].lock->lock(thread_args[i].thread_id);
-                    (*counter)++; // Critical section
-                    thread_args[i].lock->unlock(thread_args[i].thread_id);
-                }
-
-                // End the timer for this thread
-                end_timer(&thread_args[i].stats);
-            });
-        } else {
-            // Measure individual lock operations
-            // May be affected by how long the clock takes to read
-            threads[i] = std::thread([&thread_args, i, counter]() {
-
-                // Record the thread ID
-                thread_args[i].stats.thread_id = thread_args[i].thread_id;
-                init_lock_timer(&thread_args[i].stats);
-            
-                // Each thread will run this function
-                while (!*thread_args[i].start_flag) {
-                    // Wait until the start flag is set
-                }
-
-                // Perform the locking operations
-                for (int j = 0; j < thread_args[i].stats.num_iterations; ++j) {
-                    start_lock_timer(&thread_args[i].stats, j);
-                    thread_args[i].lock->lock(thread_args[i].thread_id);
-                    (*counter)++; // Critical section
-                    thread_args[i].lock->unlock(thread_args[i].thread_id);
-                    end_lock_timer(&thread_args[i].stats, j);
-                }
-            });
-        }
+                thread_args[i].lock->lock(thread_args[i].thread_id);
+                thread_args[i].stats.num_iterations++;
+                (*counter)++;
+                // Critical section code goes here
+                thread_args[i].lock->unlock(thread_args[i].thread_id);
+            }
+            thread_args[i].stats.num_iterations--;
+        });
     }
 
     // Start the threads
     *start_flag = true; // Set the start flag to signal the threads to begin
+    std::this_thread::sleep_for(run_time);
+    *end_flag = true;
+
+    
 
     // Wait for all threads to finish
     for (auto& thread : threads) {
@@ -105,9 +80,16 @@ void max_contention_bench(int num_threads, int num_iterations, bool csv, bool th
         }
     }
 
-    if (*counter != num_threads * num_iterations) {
+    *counter -= num_threads;
+
+    int expectedIterations = 0;
+    for (int i =0; i<num_threads; i++){
+        expectedIterations+=thread_args[i].stats.num_iterations;
+    }
+
+    if (*counter != expectedIterations) {
         // The mutex did not work.
-        fprintf(stderr, "Mutex %s failed; *counter != num_threads * num_iterations (%d!=%d)\n", lock->name().c_str(), *counter, num_threads * num_iterations);
+        fprintf(stderr, "Mutex %s failed; *counter != num_threads * num_iterations (%d!=%d)\n", lock->name().c_str(), *counter, expectedIterations);
         return 1;
     }
 
@@ -121,7 +103,7 @@ void max_contention_bench(int num_threads, int num_iterations, bool csv, bool th
     // Output benchmark results
 
     for (auto& args : thread_args) {
-        report_thread_latency(&args.stats, csv, thread_level); // Report latency for each thread
+        report_thread_stats(&args.stats, csv); // Report latency for each thread
     }
 
     // record_rusage(); // Record resource usage
@@ -130,16 +112,16 @@ void max_contention_bench(int num_threads, int num_iterations, bool csv, bool th
 
 int main(int argc, char* argv[]) {
     if (argc < 3) {
-        fprintf(stderr, "Usage: %s <mutex_name> <num_threads> <num_iterations> [<flags>]\n", argv[0]);
+        fprintf(stderr, "Usage: %s <mutex_name> <num_threads> <run_time> <flags>]\n", argv[0]);
         return 1;
     }
 
     // First, take in command line arguments
     char *mutex_name = nullptr;
     int num_threads = -1;
-    int num_iterations = -1;
     bool csv = false;
     bool thread_level = false;
+    int run_time =-1;
 
     for (int i = 1; i < argc; i++) 
     {
@@ -152,8 +134,8 @@ int main(int argc, char* argv[]) {
             mutex_name = argv[i];
         } else if (num_threads == -1) {
             num_threads = atoi(argv[i]);
-        } else if (num_iterations == -1) {
-            num_iterations = atoi(argv[i]);
+        } else if (run_time == -1){
+            run_time = atoi(argv[i]);
         } else {
             fprintf(stderr, "Unrecognized command line argument: %s\n", argv[i]);
             return 1;
@@ -187,7 +169,5 @@ int main(int argc, char* argv[]) {
     }    
     
     // Run the max contention benchmark
-    max_contention_bench(num_threads, num_iterations, csv, thread_level, lock);
-
-    return 0;
+    return max_contention_bench(num_threads, std::chrono::seconds(run_time), csv, lock);
 }

--- a/apps/max_contention_bench/max_contention_bench.hpp
+++ b/apps/max_contention_bench/max_contention_bench.hpp
@@ -8,6 +8,7 @@ struct per_thread_args {
     struct per_thread_stats stats;
 
     std::shared_ptr<std::atomic<bool>> start_flag; // Shared flag to signal the start of the benchmark
+    std::shared_ptr<std::atomic<bool>> end_flag;
     SoftwareMutex *lock; // Pointer to the lock object, type depends on the lock implementation
     
 };
@@ -18,4 +19,4 @@ struct run_args {
     struct rusage usage;
 };
 
-void max_contention_bench(int num_threads, int num_iterations);
+int max_contention_bench(int num_threads, std::chrono::seconds run_time, bool csv, SoftwareMutex* lock);

--- a/lib/lock/bakery_mutex.cpp
+++ b/lib/lock/bakery_mutex.cpp
@@ -45,6 +45,9 @@ public:
         free((void*)choosing);
         free((void*)number);
     }
+
+
+    std::string name(){return "bakery";}
 private:
     volatile bool *choosing;
     // Note: Mutex will fail if this number overflows,

--- a/lib/lock/dijkstra_lock.cpp
+++ b/lib/lock/dijkstra_lock.cpp
@@ -18,24 +18,28 @@ public:
         // TODO refactor and remove goto
         unlocking[thread_id] = false;
     try_again:
+        c[thread_id] = true;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
         if (k != thread_id) {
-            c[thread_id] = true;
-            if (unlocking[k]) {
-                k = thread_id;
-            }
+            while (!unlocking[k]) {}
+            k = thread_id;
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            
             goto try_again;
-        } else {
-            c[thread_id] = false;
-            for (size_t j = 0; j < num_threads; j++) {
-                if (j != thread_id && !c[j]) {
-                    goto try_again;
-                }
+        } 
+        c[thread_id] = false;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        for (size_t j = 0; j < num_threads; j++) {
+            if (j != thread_id && !c[j]) {
+                goto try_again;
             }
         }
+
     }
     void unlock(size_t thread_id) override {
-        c[thread_id] = true;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
         unlocking[thread_id] = true;
+        c[thread_id] = true;
     }
     void destroy() override {
         free((void*)unlocking);

--- a/lib/lock/exp_spin_lock.cpp
+++ b/lib/lock/exp_spin_lock.cpp
@@ -26,6 +26,8 @@ public:
         std::atomic_flag_clear_explicit(&lock_, std::memory_order_release);
     }
     void destroy() override {}
+
+    std::string name(){return "exp_spin";}
     
 private:
     volatile std::atomic_flag lock_ = ATOMIC_FLAG_INIT;

--- a/lib/utils/bench_utils.cpp
+++ b/lib/utils/bench_utils.cpp
@@ -33,69 +33,60 @@ void print_rusage(struct rusage *usage) {
     printf("Involuntary context switches: %ld\n", usage->ru_nivcsw);
 }
 
-void start_timer(struct per_thread_stats *stats) {
-    clock_gettime(CLOCK_MONOTONIC, &stats->start_time);
-}
+// void init_lock_timer(struct per_thread_stats *stats) {
+//     stats->lock_times = (double *)malloc(sizeof(double) * stats->num_iterations);
+// }
 
-void end_timer(struct per_thread_stats *stats) {
-    clock_gettime(CLOCK_MONOTONIC, &stats->end_time);
-}
+// void start_lock_timer(struct per_thread_stats *stats, size_t index) {
+//     (void)index; // Not used but could be used in the future.
+//     clock_gettime(CLOCK_MONOTONIC, &stats->start_time);
+// }
 
-void init_lock_timer(struct per_thread_stats *stats) {
-    stats->lock_times = (double *)malloc(sizeof(double) * stats->num_iterations);
-}
+// double get_elapsed_time(struct timespec start_time, struct timespec end_time) {
+//     long seconds = end_time.tv_sec - start_time.tv_sec;
+//     long nanoseconds = end_time.tv_nsec - start_time.tv_nsec;
 
-void start_lock_timer(struct per_thread_stats *stats, size_t index) {
-    (void)index; // Not used but could be used in the future.
-    clock_gettime(CLOCK_MONOTONIC, &stats->start_time);
-}
+//     if (nanoseconds < 0) {
+//         seconds--;
+//         nanoseconds += 1e9;
+//     }
 
-double get_elapsed_time(struct timespec start_time, struct timespec end_time) {
-    long seconds = end_time.tv_sec - start_time.tv_sec;
-    long nanoseconds = end_time.tv_nsec - start_time.tv_nsec;
+//     double elapsed = seconds + nanoseconds / 1e9;
+//     return elapsed;
+// }
 
-    if (nanoseconds < 0) {
-        seconds--;
-        nanoseconds += 1e9;
-    }
+// void end_lock_timer(struct per_thread_stats *stats, size_t index) {
+//     clock_gettime(CLOCK_MONOTONIC, &stats->end_time);
+//     stats->lock_times[index] = get_elapsed_time(stats->start_time, stats->end_time);
+// }
 
-    double elapsed = seconds + nanoseconds / 1e9;
-    return elapsed;
-}
-
-void end_lock_timer(struct per_thread_stats *stats, size_t index) {
-    clock_gettime(CLOCK_MONOTONIC, &stats->end_time);
-    stats->lock_times[index] = get_elapsed_time(stats->start_time, stats->end_time);
-}
-
-void report_thread_latency(struct per_thread_stats *stats, bool csv, bool thread_level) {
+void report_thread_stats(struct per_thread_stats *stats, bool csv, bool thread_level) {
     if (thread_level) {
-        double elapsed = get_elapsed_time(stats->start_time, stats->end_time);
-        
         if (csv) {
-            printf("%d,%d,%.6f\n", stats->thread_id, stats->num_iterations, elapsed);
+            printf("%d,%d,%d\n", stats->thread_id, stats->run_time.count(), stats->num_iterations);
         } else {
-            printf("Thread %d: %d iterations completed in %.6f seconds\n",
-                stats->thread_id, stats->num_iterations, elapsed);
+            printf("Thread %d: %d iterations completed in %d seconds\n",
+                stats->thread_id, stats->num_iterations, stats->run_time.count());
         }
-    } else {
-        double elapsed = get_elapsed_time(stats->start_time, stats->end_time);
+    } 
+    // else {
+    //     double elapsed = get_elapsed_time(stats->start_time, stats->end_time);
         
-        if (csv) {
-            for (int i = 0; i < stats->num_iterations; i++) {
-                // Thread ID, Iteration #, Time to lock
-                printf("%d,%d,%.9f\n", stats->thread_id, i, stats->lock_times[i]);
-            }
-        }
-        else {
-            printf("Thread %d: %d iterations completed in %.6f seconds\n",
-                stats->thread_id, stats->num_iterations, elapsed);
-            for (int i = 0; i < stats->num_iterations; i++) {
-                // Thread ID, Iteration #, Time to lock
-                printf("    #%d: iteration %d took %.9f seconds\n", stats->thread_id, i, stats->lock_times[i]);
-            }
-        }
-    }
+    //     if (csv) {
+    //         for (int i = 0; i < stats->num_iterations; i++) {
+    //             // Thread ID, Iteration #, Time to lock
+    //             printf("%d,%d,%.9f\n", stats->thread_id, i, stats->lock_times[i]);
+    //         }
+    //     }
+    //     else {
+    //         printf("Thread %d: %d iterations completed in %.6f seconds\n",
+    //             stats->thread_id, stats->num_iterations, elapsed);
+    //         for (int i = 0; i < stats->num_iterations; i++) {
+    //             // Thread ID, Iteration #, Time to lock
+    //             printf("    #%d: iteration %d took %.9f seconds\n", stats->thread_id, i, stats->lock_times[i]);
+    //         }
+    //     }
+    // }
 }
 
 void report_run_latency(struct run_args *stats){

--- a/lib/utils/bench_utils.hpp
+++ b/lib/utils/bench_utils.hpp
@@ -14,10 +14,7 @@ struct per_thread_stats {
     int thread_id;
     int num_iterations;
 
-    struct timespec start_time;
-    struct timespec end_time;
-
-    double *lock_times;
+    std::chrono::seconds run_time;
 };
 
 
@@ -40,7 +37,7 @@ void end_lock_timer(struct per_thread_stats *stats, size_t index);
 void start_timer(struct per_thread_stats *stats);
 void end_timer(struct per_thread_stats *stats);
 
-void report_thread_latency(struct per_thread_stats *stats, bool csv = false, bool thread_level = false);
+void report_thread_stats(struct per_thread_stats *stats, bool csv = false, bool thread_level = true);
 void report_run_latency(struct run_stats *stats);
 
 #endif // __BENCH_UTILS_HPP_

--- a/scripts/analyzer.py
+++ b/scripts/analyzer.py
@@ -3,6 +3,7 @@ from .plotter import plot_one_cdf, plot_one_graph, finish_plotting_cdf, finish_p
 
 import pandas as pd
 import numpy as np
+import matplotlib.pyplot as plt
 
 def analyze(data):
     # TODO add more stuff here
@@ -43,16 +44,34 @@ def analyze_lock_level(data):
 def analyze_iter_v_threads(data):
     output=""
     output +="\n"
+    figure, axis = plt.subplots(1, 2)
     for mutex_name in Constants.mutex_names:
-        output += f"Mutex {mutex_name:>8} average time: {np.array(data[mutex_name]).mean():.7f} standard deviation: {np.array(data[mutex_name]).mean():.7f}\n"
+        # output += f"Mutex {mutex_name:>8} average time: {np.array(data[mutex_name]).mean():.7f} standard deviation: {np.array(data[mutex_name]).mean():.7f}\n"
+        mean_values = [thread.mean() for thread in data[mutex_name]]
+        print(mean_values)
         plot_one_graph(
+            axis[0],
             np.array(range(Constants.threads_start, Constants.threads_end, Constants.threads_step)),
-            np.array(data[mutex_name]),
+            mean_values,
             mutex_name,
             xlabel="# of Threads",
             ylabel="# Iterations",
             title=f"{mutex_name}",
             skip=0
         )
-    finish_plotting_graph()
+
+        stdev_values = [np.std(thread) for thread in data[mutex_name]]
+        plot_one_graph(
+            axis[1],
+            np.array(range(Constants.threads_start, Constants.threads_end, Constants.threads_step)),
+            stdev_values,
+            mutex_name,
+            xlabel="# of Threads",
+            ylabel="# Iterations",
+            title=f"{mutex_name}",
+            skip=0
+        )
+
+        
+    finish_plotting_graph(axis)
     return output

--- a/scripts/analyzer.py
+++ b/scripts/analyzer.py
@@ -1,24 +1,25 @@
 from .constants import *
-from .plotter import plot_one_cdf, finish_plotting_cdf
+from .plotter import plot_one_cdf, plot_one_graph, finish_plotting_cdf, finish_plotting_graph
 
 import pandas as pd
+import numpy as np
 
 def analyze(data):
     # TODO add more stuff here
     output = ""
     output += "\n"
     for mutex_name in Constants.mutex_names:
-        output += f"Mutex {mutex_name:>8} average time: {data[mutex_name]['Time Spent'].mean():.7f} standard deviation: {data[mutex_name]['Time Spent'].std():.7f}\n"
+        output += f"Mutex {mutex_name:>8} average iterations: {data[mutex_name]['# Iterations'].mean():.7f} standard deviation: {data[mutex_name]['# Iterations'].std():.7f}\n"
         plot_one_cdf(
-            data[mutex_name]["Time Spent"], 
+            data[mutex_name]["# Iterations"], 
             mutex_name,
-            xlabel="Thread time (seconds)",
+            xlabel="Thread iterations (counts)",
             ylabel="% of threads under",
             title=f"{mutex_name}",
             skip=0,
             # worst_case=worst_case
         )
-    finish_plotting_cdf("Thread time")
+    finish_plotting_cdf("Thread iterations")
     return output
 
 def analyze_lock_level(data):
@@ -37,4 +38,21 @@ def analyze_lock_level(data):
             # worst_case=worst_case
         )
     finish_plotting_cdf("Lock time")
+    return output
+
+def analyze_iter_v_threads(data):
+    output=""
+    output +="\n"
+    for mutex_name in Constants.mutex_names:
+        output += f"Mutex {mutex_name:>8} average time: {np.array(data[mutex_name]).mean():.7f} standard deviation: {np.array(data[mutex_name]).mean():.7f}\n"
+        plot_one_graph(
+            np.array(range(Constants.threads_start, Constants.threads_end, Constants.threads_step)),
+            np.array(data[mutex_name]),
+            mutex_name,
+            xlabel="# of Threads",
+            ylabel="# Iterations",
+            title=f"{mutex_name}",
+            skip=0
+        )
+    finish_plotting_graph()
     return output

--- a/scripts/args.py
+++ b/scripts/args.py
@@ -12,12 +12,16 @@ def init_args():
         epilog=''
     )
     parser.add_argument('threads', type=int)
-    parser.add_argument('iterations', type=int)
+    parser.add_argument('seconds', type=int)
     parser.add_argument('program_iterations', type=int)
+    parser.add_argument('threads_start', type=int, default=0)
+    parser.add_argument('threads_end', type=int, default=0)
+    parser.add_argument('threads_step', type=int, default=0)
 
     experiment_type = parser.add_mutually_exclusive_group()
     experiment_type.add_argument('--thread-level', action='store_true')
     experiment_type.add_argument('--lock-level', action='store_true')
+    experiment_type.add_argument('--iter-v-threads', action = 'store_true')
 
     parser.add_argument('-l', '--log', type=str, default=Constants.Defaults.LOG)
     parser.add_argument('-s', '--skip', type=int, default=Constants.Defaults.SKIP)
@@ -49,14 +53,18 @@ def init_args():
         Constants.mutex_names = [x for x in Constants.Defaults.MUTEX_NAMES if x not in args.exclude]
     
     Constants.bench_n_threads = args.threads
-    Constants.bench_n_iterations = args.iterations
+    Constants.bench_n_seconds = args.seconds
     Constants.n_program_iterations = args.program_iterations
+    Constants.threads_start = args.threads_start
+    Constants.threads_end = args.threads_end
+    Constants.threads_step = args.threads_step
     Constants.data_folder = args.data_folder
     logger.debug(Constants.data_folder)
     Constants.logs_folder = args.log_folder
     Constants.executable = Constants.Defaults.EXECUTABLE
     Constants.multithreaded = args.multithreaded
     Constants.thread_level = args.thread_level
+    Constants.iter_v_threads = args.iter_v_threads
     Constants.scatter = args.scatter
     Constants.skip = args.skip
 

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -2,16 +2,16 @@ import logging
 
 class Constants:
     class Defaults:
-        MUTEX_NAMES = ["dijkstra", "bakery", "spin", "exp_spin", "nsync", "boost", "cpp_std", "pthread"]
+        MUTEX_NAMES = ["dijkstra", "bakery", "spin", "exp_spin", "nsync", "pthread"]
         EXECUTABLE_NAME = "max_contention_bench"
         BENCH_N_THREADS = "10"
-        BENCH_N_ITERATIONS = "100"
+        BENCH_N_SECONDS = "1"
         N_PROGRAM_ITERATIONS = 10
         DATA_FOLDER = "./data/generated"
         LOGS_FOLDER = "./data/logs"
         EXECUTABLE = f"./build/apps/{EXECUTABLE_NAME}/{EXECUTABLE_NAME}"
         MULTITHREADED = False
-        THREAD_LEVEL = False
+        THREAD_LEVEL = True
         SCATTER = False
         LOG = logging.INFO
         SKIP = 10

--- a/scripts/dataloader.py
+++ b/scripts/dataloader.py
@@ -37,6 +37,5 @@ def load_data_iter_v_threads():
                 dataframe = pd.read_csv(data_file_name, names=["Thread ID", "Seconds", "# Iterations"])
                 dataframes.append(dataframe)
             dataframes=pd.concat(dataframes)
-            data[mutex_name].append(dataframes["# Iterations"].mean())
-            print(data[mutex_name])
+            data[mutex_name].append(dataframes["# Iterations"])
     return data

--- a/scripts/dataloader.py
+++ b/scripts/dataloader.py
@@ -10,7 +10,7 @@ def load_data():
         dataframes = []
         for i in range(Constants.n_program_iterations):
             data_file_name = f"{Constants.data_folder}/{mutex_name}-{i}.csv"
-            dataframe = pd.read_csv(data_file_name, names=["Thread #", "# Iterations", "Time Spent"])
+            dataframe = pd.read_csv(data_file_name, names=["Thread #", "Seconds", "# Iterations"])
             dataframes.append(dataframe)
         data[mutex_name] = pd.concat(dataframes)
     return data
@@ -24,4 +24,19 @@ def load_data_lock_level():
             dataframe = pd.read_csv(data_file_name, names=["Thread ID", "Iteration #", "Time Spent"])
             dataframes.append(dataframe)
         data[mutex_name] = pd.concat(dataframes)
+    return data
+
+def load_data_iter_v_threads():
+    data = {}
+    for mutex_name in Constants.mutex_names:
+        data[mutex_name]=[]
+        for threads in range(Constants.threads_start, Constants.threads_end, Constants.threads_step):
+            dataframes=[]
+            for i in range(Constants.n_program_iterations):
+                data_file_name = f"{Constants.data_folder}/{mutex_name}-{threads}-{i}.csv"
+                dataframe = pd.read_csv(data_file_name, names=["Thread ID", "Seconds", "# Iterations"])
+                dataframes.append(dataframe)
+            dataframes=pd.concat(dataframes)
+            data[mutex_name].append(dataframes["# Iterations"].mean())
+            print(data[mutex_name])
     return data

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -21,12 +21,19 @@ def run_experiment_thread_level():
     data = load_data()
     output = analyze(data)
     print(output)
-    log(output)
+    logger.info(output)
 
 def run_experiment_lock_level():
     run_experiment_lock_level_single_threaded()
     data = load_data_lock_level()
     output = analyze_lock_level(data)
+    print(output)
+    logger.info(output)
+
+def run_experiment_iter_v_threads():
+    run_experiment_iter_v_threads_single_threaded()
+    data = load_data_iter_v_threads()
+    output = analyze_iter_v_threads(data)
     print(output)
     logger.info(output)
 
@@ -38,6 +45,8 @@ def main():
     build()
     if Constants.thread_level:
         run_experiment_thread_level()
+    elif Constants.iter_v_threads:
+        run_experiment_iter_v_threads()
     else:
         run_experiment_lock_level()
 

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -12,12 +12,20 @@ def finish_plotting_cdf(thread_time_or_lock_time):
         handle._sizes = [30]
     plt.show()
 
-def finish_plotting_graph():
+def finish_plotting_graph(axis):
     print("Finishing plotting...")
-    plt.title(f"# Iterations v threads for {Constants.bench_n_seconds} seconds ({Constants.n_program_iterations}x)")
-    plt.yscale('log')
+    axis[0].set_title(f"# Iterations v threads for {Constants.bench_n_seconds} seconds ({Constants.n_program_iterations}x)")
+    axis[0].set_yscale('log')
+
+    axis[1].set_title(f"Std. dev of # Iterations v threads for {Constants.bench_n_seconds} seconds ({Constants.n_program_iterations}x)")
+    axis[1].set_yscale('log')
     # plt.xscale('log')
-    legend = plt.legend()
+    legend = axis[0].legend()
+    for handle in legend.legend_handles:
+        handle._sizes = [30]
+    
+
+    legend = axis[1].legend()
     for handle in legend.legend_handles:
         handle._sizes = [30]
     plt.show()
@@ -40,13 +48,13 @@ def plot_one_cdf(series, mutex_name, xlabel="", ylabel="", title="", skip=-1, wo
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
 
-def plot_one_graph(x, y, mutex_name, xlabel="", ylabel="", title="", skip=-1, worst_case=-1):
+def plot_one_graph(ax, x, y, mutex_name, xlabel="", ylabel="", title="", skip=-1, worst_case=-1):
     if skip == -1:
         skip = Constants.skip
     logger.info(f"Plotting {mutex_name=}")
     if Constants.scatter:
-        plt.scatter(x, y, label=title, s=0.2)
+        ax.scatter(x, y, label=title, s=0.2)
     else:
-        plt.plot(x, y, label=title)
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
+        ax.plot(x, y, label=title)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -5,8 +5,18 @@ import matplotlib.pyplot as plt
 
 def finish_plotting_cdf(thread_time_or_lock_time):
     print("Finishing plotting...")
-    plt.title(f"{thread_time_or_lock_time} CDF for {Constants.bench_n_threads} threads and {Constants.bench_n_iterations} iterations ({Constants.n_program_iterations}x)")
+    plt.title(f"{thread_time_or_lock_time} CDF for {Constants.bench_n_threads} threads and {Constants.bench_n_seconds} seconds ({Constants.n_program_iterations}x)")
     plt.xscale('log')
+    legend = plt.legend()
+    for handle in legend.legend_handles:
+        handle._sizes = [30]
+    plt.show()
+
+def finish_plotting_graph():
+    print("Finishing plotting...")
+    plt.title(f"# Iterations v threads for {Constants.bench_n_seconds} seconds ({Constants.n_program_iterations}x)")
+    plt.yscale('log')
+    # plt.xscale('log')
     legend = plt.legend()
     for handle in legend.legend_handles:
         handle._sizes = [30]
@@ -23,6 +33,17 @@ def plot_one_cdf(series, mutex_name, xlabel="", ylabel="", title="", skip=-1, wo
     x = [x_values[i] for i in range(0, x_values.size, 1 + skip)]
     y = [y_values[i] for i in range(0, x_values.size, 1 + skip)]
 
+    if Constants.scatter:
+        plt.scatter(x, y, label=title, s=0.2)
+    else:
+        plt.plot(x, y, label=title)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+
+def plot_one_graph(x, y, mutex_name, xlabel="", ylabel="", title="", skip=-1, worst_case=-1):
+    if skip == -1:
+        skip = Constants.skip
+    logger.info(f"Plotting {mutex_name=}")
     if Constants.scatter:
         plt.scatter(x, y, label=title, s=0.2)
     else:


### PR DESCRIPTION
Switches max_contention_bench over so that it runs for a given time, and the number of lock/unlocks it can do is what is to be measured. This breaks/puts out of use lock timing (needs to be fixed).