### PR TITLE
better correctness measurements

### DIFF
--- a/apps/max_contention_bench/meson.build.sanitized
+++ b/apps/max_contention_bench/meson.build.sanitized
@@ -1,0 +1,17 @@
+link_with = [
+  lock_lib,
+  utils_lib,
+]
+
+include_directories = [
+  lock_includes,
+  utils_includes,
+]
+
+max_contention_bench = executable(
+  'max_contention_bench',
+  'max_contention_bench.cpp',
+  dependencies : [lock_dep, utils_dep, boost_dep, nsync_dep],
+  cpp_args: '-fsanitize=thread',
+  link_args: '-fsanitize=thread'
+)

--- a/unit-test.sh
+++ b/unit-test.sh
@@ -1,0 +1,9 @@
+cp ./apps/max_contention_bench/meson.build ./apps/max_contention_bench/meson.build.tmp
+cp ./apps/max_contention_bench/meson.build.sanitized ./apps/max_contention_bench/meson.build
+meson setup build
+cd build
+meson compile
+./apps/max_contention_bench/max_contention_bench $1 10 $2 0 --thread-level | grep "data race max"
+cd ../
+cp ./apps/max_contention_bench/meson.build.tmp ./apps/max_contention_bench/meson.build 
+rm ./apps/max_contention_bench/meson.build.tmp


### PR DESCRIPTION
uses threadsanitize to determine correctness (suspiciously fails on all non-atomic mutexes??)